### PR TITLE
Add parsing of AMT_URL and AMT_RELAY

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,13 @@ git submodule init
 git submodule update
 sudo pip3 install threefive
 sudo pip3 install scapy
-sudo python3 mt-play.py
+AMT_URL=xxx sudo python3 -E amt-play.py
 open http://localhost:8080
 ```
+
+Please determine your AMT_URL and change xxx to that.
+
+(NB: You must provide the -E switch to sudo so that it pulls the AMT_URL into the root environment.)
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,63 @@
 Requires git, python3.6
 
+# Running
 
 ```
 git clone https://github.com/vivoh-inc/amt-play
+cd amt-play
 git submodule init
 git submodule update
 sudo pip3 install threefive
 sudo pip3 install scapy
 sudo python3 mt-play.py
 open http://localhost:8080
+```
+
+# Usage
+
+You must provide an environment variable named AMT_URL. 
+
+You can optionally use AMT_RELAY to provide a relay URL. 
+
+AMT_URL supports two formats:
+  a legacy URL (like that used in VLC)
+  a parameterized URL (with URL query parameters)
+
+Legacy AMT URL:
+
+AMT_URL=amt://162.250.138.201@232.162.250.138:1234 \\
+    AMT_RELAY=162.250.137.254 \\
+    sudo -E python3 amt-play.py
+
+Parameterized AMT URL:
+
+AMT_URL=amt://232.162.250.138:1234?relay=162.250.137.254&timeout=2&source=162.250.138.201 \\
+    sudo -E python3 amt-play.py 
+
+The query parameters should be:
+
+* relay
+* timeout (ignored for now)
+* source
+
+(you may pass a relay IP with the parameterized AMT_URL and that will
+override the relay from the query string)
+
+# Developer Notes
+
+Start in amt-play.py. This has four functions: `parse_arguments`, `start_segmenter`, `start_amt_tunnel(relay, source, multicast)` and `start_web_server`. 
+
+The `parse_arguments` code is straightforwar: we parse the arguments (the AMT_URL and AMT_RELAY variables). 
+
+Each of the next set of functions starts a thread to handle functionality for the segmenter, amt tunnel and the web server.
+
+The segmenter code relies on a project called [X9K3](https://github.com/futzu/x9k3) which converts UDP video packets into HLS streams and then dumps the index.m3u8 and TS files into a directory (currently hardcoded to "files"). 
+
+The AMT tunnel code does the AMT dance: sending a relay discovery, sending the relay advertisement, and then
+issuing the multicast join. If you use VLC (4.0+) with an AMT URL and watch traffic in Wireshark, you will see the equivalent
+network calls recorded by Wireshark to what we do in code here. Once the AMT tunnel is created, the script loops
+to receiving the packets and sends them to 127.0.0.1:3000 (and the segmenter picks them up and converts them).
+
+The web code sets up a simple web server on 127.0.0.1:8080 to serve the index.html, JS and CSS files, and the m3u8 file
+which points to TS files. The only thing special about the server code is that it disables caching so that when the
+browser requests the m3u8 file it is always delivered with the latest content.

--- a/argparser.py
+++ b/argparser.py
@@ -1,0 +1,34 @@
+from audioop import mul
+
+
+def process_amt_url(amt, relay_tmp = None):
+    multicast = ""
+    source = ""
+    relay = ""
+    timeout = 1000
+
+    if "?" in amt:
+        # process with query parameters
+        mpre, queries = amt.split("?")
+        multicast = mpre.replace("amt://", "")
+        qs = queries.split('&')
+        for q in qs:
+            k,v = q.split("=")
+            if k == "source":
+                source = v
+            elif k == "multicast":
+                multicast = v
+            elif k == "timeout":
+                timeout = v
+            elif k == "relay":
+                relay = v
+
+    else:
+        a, m = amt.split("@")
+        source = a.replace("amt://", "")
+        multicast = m
+    
+    if relay_tmp:
+        relay = relay_tmp
+        
+    return [ relay, multicast, source, timeout] 

--- a/argument_parser_test.py
+++ b/argument_parser_test.py
@@ -1,0 +1,25 @@
+import unittest
+from argparser import process_amt_url
+
+class TestAmtArgParser(unittest.TestCase):
+
+    legacy = "amt://162.250.138.201@232.162.250.138:1234"
+    relay = "162.250.137.254"
+    parameterized = "amt://232.162.250.138:1234?relay=162.250.137.254&timeout=2&source=162.250.138.201"
+
+    def test_legacy(self):
+        r, m, s, t = process_amt_url(self.legacy, self.relay)
+        self.assertEqual(r, "162.250.137.254")
+        self.assertEqual(m, "232.162.250.138:1234")
+        self.assertEqual(s, "162.250.138.201")
+        self.assertEqual(t, 1000)
+
+    def test_paramterized(self):
+        r, m, s, t = process_amt_url(self.parameterized)
+        self.assertEqual(r, "162.250.137.254")
+        self.assertEqual(m, "232.162.250.138:1234")
+        self.assertEqual(s, "162.250.138.201")
+        self.assertEqual(t, '2')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/segmenter.py
+++ b/segmenter.py
@@ -4,10 +4,10 @@ from new_reader import reader
 
 def _segmenter():
     print("Starting segmenter")
-    x9k3 = X9K3()
+    x9k3 = X9K3("udp://127.0.0.1:3000")
     # print(x9k3)
     x9k3.live = True
-    x9k3._tsdata = reader("udp://127.0.0.1:3000")
+    # x9k3._tsdata = reader()
     x9k3.output_dir = "files"
     x9k3.decode()
 


### PR DESCRIPTION
From the readme:

```
You must provide an environment variable named AMT_URL. 

You can optionally use AMT_RELAY to provide a relay URL. 

AMT_URL supports two formats:
  a legacy URL (like that used in VLC)
  a parameterized URL (with URL query parameters)

Legacy AMT URL:

AMT_URL=amt://162.250.138.201@232.162.250.138:1234 \\
    AMT_RELAY=162.250.137.254 \\
    sudo -E python3 amt-play.py

Parameterized AMT URL:

AMT_URL=amt://232.162.250.138:1234?relay=162.250.137.254&timeout=2&source=162.250.138.201 \\
    sudo -E python3 amt-play.py 

The query parameters should be:

* relay
* timeout (ignored for now)
* source

(you may pass a relay IP with the parameterized AMT_URL and that will
override the relay from the query string)
```